### PR TITLE
Add venv site-packages dir to PYTHONPATH

### DIFF
--- a/containerfiles/multi/Rocm_Multipurpose
+++ b/containerfiles/multi/Rocm_Multipurpose
@@ -228,6 +228,4 @@ RUN set -ue; \
   jq -n --argjson apt "$apt_json"  --argjson pip "$pip_json" '{apt: $apt, pip: $pip}' > /.sbom.json;
 
 
-ENV PATH="/opt/venv/bin:$PATH"
-
 CMD ["/bin/bash"]

--- a/containerfiles/torch/Venv_Torch
+++ b/containerfiles/torch/Venv_Torch
@@ -17,7 +17,6 @@ RUN set -ue; \
   . /opt/venv/bin/activate; \
   pip install $PYTORCH_TRITON_URL $TORCHAUDIO_URL $TORCHVISION_URL $TORCH_URL; \
   pip cache purge; \
-  echo "source /opt/venv/bin/activate" >> ~/.bashrc; \
   #
   # Add SBOM
   #
@@ -26,5 +25,6 @@ RUN set -ue; \
   jq -n --argjson apt "$apt_json"  --argjson pip "$pip_json" '{apt: $apt, pip: $pip}' > /.sbom.json;
 
 ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONPATH="/opt/venv/lib/python3.12/site-packages:$PYTHONPATH"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Because the system-wide Python environment of the container is managed by the base image OS, using `pip` to install packages to this environment is discouraged. Therefore, when we build the image, we install packages in a virtual environment. However, we also want to allow users to install additional packages in their own venv, whose activation in turn deactivates the image's venv.

We solve this by manually adding the image venv's `site-packages` directory, which holds its installed Python packages, to the image's `PYTHONPATH` environment variable, which is Python's search path for module files. When this is done, the image venv does not need to be activated in order to use its installed packages.