### PR TITLE
Use Apptainer for building SIF containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ The workflow is designed to make it easy to update software versions, rebuild im
 The build environment requires:
 - **Ubuntu 24.04 LTS**
 - **Packages**:
+  - `apptainer`
   - `buildah`
   - `jq`
   - `podman`
   - `python3-ruamel.yaml`
-  - `singularity-container`
   - `yq`
 - **For ARM builds on x86 hosts**:
   - `qemu-user-static`
@@ -121,7 +121,7 @@ A build produces:
 - A **rendered recipe** (`<recipe>-<build-id>.yaml`).
 - **Release documentation** (Markdown files).
 - **SBOM files** (JSON format) for quick version checks.
-- **Build logs** and **Singularity image files** (`.sif`).
+- **Build logs** and **Singularity Image Format containers** (`.sif`).
 
 All outputs are saved in `builds/<recipe-name>-<build-id>/`.
 

--- a/recipes/lumi-multitorch/lumi-multitorch-template.yaml
+++ b/recipes/lumi-multitorch/lumi-multitorch-template.yaml
@@ -64,8 +64,8 @@ desc: |
   on other similar systems, as well as adapting the images to run on cloud
   environments.
 
-  All images are published to Docker Hub, and ready-to-run Apptainer/Singularity
-  `.sif` versions of the images are available directly on LUMI. The generated
+  All images are published to Docker Hub, and ready-to-run Singularity Image Format
+  (SIF) versions of the images are available directly on LUMI. The generated
   Containerfiles and other artifacts are released as public GitHub releases.
 
   The release identifier `{{release_id}}` encodes
@@ -146,7 +146,7 @@ desc: |
     - A `.yaml` recipe file which defines the build steps, software versions, and
       includes all required Containerfiles and documentation snippets to reproduce
       the build of this release.
-    - Containerfiles and Singularity definition files (`.Containerfile`, `.def`)
+    - Containerfiles and Apptainer definition files (`.Containerfile`, `.def`)
       for convenience (this data is embedded in the `.yaml` recipe as well).
     - This release README file and separate per-image documentation (`.md`).
     - Build logs (`.log`) and SBOM files (`.json`) for all images for
@@ -163,7 +163,7 @@ desc: |
       - `{{recipe_base_name}}-{{software_digest}}-{{build_tag}}.md`: The main readme file
       - `{{recipe_base_name}}-{{software_digest}}-{{build_tag}}.yaml`: The recipe file
       {% for type in image_variants -%}
-      - `{{ image_build_name(type) }}.sif`: Singularity image for the {{ type }} image
+      - `{{ image_build_name(type) }}.sif`: SIF image for the {{ type }} image
       - `{{ image_build_name(type) }}.md`: Readme file for the {{ type }} image
       - `{{ image_build_name(type) }}.json`: Software Bill of materials for the {{ type }} image
       {% endfor %}

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -116,7 +116,7 @@ export_image() {
 
     printf 'Bootstrap: oci-archive\nFrom: %s\n%s\n' "${OCI_FILE}" "${EXPORT_SIF_DEF}" > "$DEF_FILE"
 
-    local SIF_COMMAND="singularity build ${SIF_FILE} ${DEF_FILE}"
+    local SIF_COMMAND="apptainer build ${SIF_FILE} ${DEF_FILE}"
 
     log "*** Exporting image with command $OCI_COMMAND"
     ${OCI_COMMAND[@]} 2>&1 | sed -e 's/^/    /' | log


### PR DESCRIPTION
SIF containers are currently built using SingularityCE, which is Sylabs' fork of the original Singularity project. This commit replaces SingularityCE with Apptainer in the build pipeline. Apptainer is a continuation of the original Singularity project, which has been renamed and moved to the Linux Foundation.